### PR TITLE
Use environment variable for system32

### DIFF
--- a/lib/hosts-edit.js
+++ b/lib/hosts-edit.js
@@ -8,7 +8,7 @@ export default {
 
   config: {
     "path": {
-      "win32": "C:/Windows/System32/drivers/etc/hosts",
+      "win32": "%SYSTEM%/drivers/etc/hosts",
       "darwin": "/private/etc/hosts",
       "linux": "/etc/hosts",
     }


### PR DESCRIPTION
Windows can be installed on a different drive than `c:\`

Reference: https://technet.microsoft.com/en-us/library/dd560744(v=ws.10).aspx